### PR TITLE
Add unit option to sumQuantityType

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -584,6 +584,7 @@
     NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:@"startDate"] longValue]];
     NSDate *endDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:@"endDate"] longValue]];
     NSString *sampleTypeString = [args objectForKey:@"sampleType"];
+    NSString *unitString = [args objectForKey:@"unit"];
     
     
     HKQuantityType *type = [HKObjectType quantityTypeForIdentifier:sampleTypeString];
@@ -600,6 +601,7 @@
     NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
     HKStatisticsOptions sumOptions = HKStatisticsOptionCumulativeSum;
     HKStatisticsQuery *query;
+    HKUnit *unit = unitString!=nil ? [HKUnit unitFromString:unitString] : [HKUnit countUnit];
     query = [[HKStatisticsQuery alloc] initWithQuantityType:type
                                     quantitySamplePredicate:predicate
                                                     options:sumOptions
@@ -608,7 +610,7 @@
                                                               NSError *error)
              {
                  HKQuantity *sum = [result sumQuantity];
-                 CDVPluginResult* response = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:[sum doubleValueForUnit:[HKUnit countUnit]]];
+                 CDVPluginResult* response = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:[sum doubleValueForUnit:unit]];
                  [self.commandDelegate sendPluginResult:response callbackId:command.callbackId];
              }];
     


### PR DESCRIPTION
Allow sumQuantityType to take in a unit parameter, defaulting to countUnit, which was the hardcoded unit before.