### PR TITLE
Don't request authorization for writing workouts when finding workouts.

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -192,7 +192,7 @@
   }
   
   NSSet *types = [NSSet setWithObjects:[HKWorkoutType workoutType], nil];
-  [self.healthStore requestAuthorizationToShareTypes:types readTypes:types completion:^(BOOL success, NSError *error) {
+  [self.healthStore requestAuthorizationToShareTypes:nil readTypes:types completion:^(BOOL success, NSError *error) {
     if (!success) {
       dispatch_sync(dispatch_get_main_queue(), ^{
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];


### PR DESCRIPTION
The current implementation for findWorkouts requests both read and write authorization. For apps that don't write workouts, this requires an unneeded authorization. It can also result in multiple invocations of the HealthKit permission screen if you don't initially use the authorization request and specify writing workouts as well.