### PR TITLE
+ Add HKWorkoutActivityTypeOther

### DIFF
--- a/src/ios/WorkoutActivityConversion.m
+++ b/src/ios/WorkoutActivityConversion.m
@@ -119,6 +119,8 @@
       return @"HKWorkoutActivityTypeWrestling";
     case HKWorkoutActivityTypeYoga:
       return @"HKWorkoutActivityTypeYoga";
+    case HKWorkoutActivityTypeOther:
+      return @"HKWorkoutActivityTypeOther";
     default:
       return @"unknown";
   }
@@ -237,6 +239,8 @@
     return HKWorkoutActivityTypeWaterSports;
   } else if ([which isEqualToString:@"HKWorkoutActivityTypeWrestling"]) {
     return HKWorkoutActivityTypeWrestling;
+  } else if ([which isEqualToString:@"HKWorkoutActivityTypeOther"]) {
+    return HKWorkoutActivityTypeOther;
   } else {
     return HKWorkoutActivityTypeYoga;
   }


### PR DESCRIPTION
This request is to add HKWorkoutActivityTypeOther into the list, I'm not sure if this is a new item with iOS 9 or not but I've added it and it works. 

If you use that it defaults to Yoga which has a different measurement value. Other defaults to 3000 units. 