### PR TITLE
Workout permissions

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -42,8 +42,17 @@ static NSString *const HKPluginKeyUUID = @"UUID";
   NSArray *readTypes = [args objectForKey:HKPluginKeyReadTypes];
   NSSet *readDataTypes = [[NSSet alloc] init];
   for (int i=0; i<[readTypes count]; i++) {
+      
     NSString *elem = [readTypes objectAtIndex:i];
-    HKObjectType *type = [self getHKObjectType:elem];
+      
+    HKObjectType *type = nil;
+      
+    if([elem isEqual: @"HKWorkoutTypeIdentifier"]) {
+        type = [self getHKObjectType:elem];
+    }else{
+        type = [HKObjectType workoutType];
+    }
+      
     if (type == nil) {
       CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"readTypes contains an invalid value"];
       [result setKeepCallbackAsBool:YES];
@@ -59,7 +68,15 @@ static NSString *const HKPluginKeyUUID = @"UUID";
   NSSet *writeDataTypes = [[NSSet alloc] init];
   for (int i=0; i<[writeTypes count]; i++) {
     NSString *elem = [writeTypes objectAtIndex:i];
-    HKObjectType *type = [self getHKObjectType:elem];
+    
+      HKObjectType *type = nil;
+      
+      if([elem isEqual: @"HKWorkoutTypeIdentifier"]) {
+          type = [self getHKObjectType:elem];
+      }else{
+          type = [HKObjectType workoutType];
+      }
+      
     if (type == nil) {
       CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"writeTypes contains an invalid value"];
       [result setKeepCallbackAsBool:YES];


### PR DESCRIPTION
I'm not sure if I'm missing it anywhere but I don't think there is a way to pre-allow the permissions for workouts. I am using this plugin with with an Apple Watch app and the issue is the Watch app keeps requesting the workout permissions on my iPhone because it wasn't done previously, but because the plugin doesn't know what that permission is when it authorizes it doesn't actually bring up the option to do so.

I'm sure there is a nicer way to implement this but I am not very proficient in obj-c. I might dive into it further, not sure.

Let me know what you think