### PR TITLE
ISO 8601 format for dates and queryDailySampleTypeStats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+.DS_Store

--- a/src/ios/HealthKit.h
+++ b/src/ios/HealthKit.h
@@ -26,6 +26,8 @@
 - (void) sumQuantityType:(CDVInvokedUrlCommand*)command;
 - (void) querySampleType:(CDVInvokedUrlCommand*)command;
 
+- (void) querySampleTypeStats:(CDVInvokedUrlCommand*)command;
+
 - (void) saveQuantitySample:(CDVInvokedUrlCommand*)command;
 - (void) saveCorrelation:(CDVInvokedUrlCommand*)command;
 - (void) queryCorrelationType:(CDVInvokedUrlCommand*)command;

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -860,93 +860,81 @@ static NSString *const HKPluginKeyUUID = @"UUID";
   }];
 }
 
-- (void) queryCorrelationType:(CDVInvokedUrlCommand*)command {
-  NSMutableDictionary *args = [command.arguments objectAtIndex:0];
-  NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:HKPluginKeyStartDate] longValue]];
-  NSDate *endDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:HKPluginKeyEndDate] longValue]];
-  NSString *correlationTypeString = [args objectForKey:HKPluginKeyCorrelationType];
-  NSString *unitString = [args objectForKey:HKPluginKeyUnit];
-  
-  HKCorrelationType *type = (HKCorrelationType*)[self getHKSampleType:correlationTypeString];
-  if (type==nil) {
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"sampleType was invalid"];
-    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-    return;
-  }
-  HKUnit *unit = unitString!=nil ? [HKUnit unitFromString:unitString] : nil;
-  // TODO check that unit is compatible with sampleType if sample type of HKQuantityType
-  NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
-  
-  HKCorrelationQuery *query = [[HKCorrelationQuery alloc] initWithType:type predicate:predicate samplePredicates:nil completion:^(HKCorrelationQuery *query, NSArray *correlations, NSError *error) {
-    if (error) {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
+//Get aggregated data in a day
+- (void) queryDailySampleTypeStats:(CDVInvokedUrlCommand*)command {
+    NSMutableDictionary *args = [command.arguments objectAtIndex:0];
+    NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:HKPluginKeyStartDate] longValue]];
+    NSDate *endDate = [NSDate dateWithTimeIntervalSince1970:[[args objectForKey:HKPluginKeyEndDate] longValue]];
+
+    NSString *sampleTypeString = [args objectForKey:HKPluginKeySampleType];
+    NSString *unitString = [args objectForKey:HKPluginKeyUnit];
+    
+    //VITO
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDateComponents *interval = [[NSDateComponents alloc] init];
+    interval.day = 1; //TODO pass as argument
+    
+    NSDateComponents *anchorComponents = [calendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
+                                                     fromDate:endDate]; //[NSDate date]];
+    anchorComponents.hour = 0; //at 00:00 AM
+    NSDate *anchorDate = [calendar dateFromComponents:anchorComponents];
+    HKQuantityType *quantityType = [HKObjectType quantityTypeForIdentifier:sampleTypeString];
+    
+    
+    if (quantityType==nil) {
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"sampleType was invalid"];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-      });
-    } else {
-      NSDateFormatter *df = [[NSDateFormatter alloc] init];
-      [df setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
-      
-      NSMutableArray *finalResults = [[NSMutableArray alloc] initWithCapacity:correlations.count];
-      for (HKSample *sample in correlations) {
-        NSDate *startSample = sample.startDate;
-        NSDate *endSample = sample.endDate;
-        NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                      [df stringFromDate:startSample], HKPluginKeyStartDate,
-                                      [df stringFromDate:endSample], HKPluginKeyEndDate,
-                                      nil];
-        if ([sample isKindOfClass:[HKCategorySample class]]) {
-          HKCategorySample *csample = (HKCategorySample *)sample;
-          [entry setValue:[NSNumber numberWithLong:csample.value] forKey:HKPluginKeyValue];
-          [entry setValue:csample.categoryType.identifier forKey:@"catagoryType.identifier"];
-          [entry setValue:csample.categoryType.description forKey:@"catagoryType.description"];
-        } else if ([sample isKindOfClass:[HKCorrelation class]]) {
-          HKCorrelation* correlation = (HKCorrelation*)sample;
-          [entry setValue:correlation.correlationType.identifier forKey:HKPluginKeyCorrelationType];
-          // correlation.metadata may contain crap which can't be parsed to valid JSON data
-          if (correlation.metadata == nil || ![NSJSONSerialization isValidJSONObject:correlation.metadata]) {
-            [entry setValue:@{} forKey:HKPluginKeyMetadata];
-          } else {
-            [entry setValue:correlation.metadata forKey:HKPluginKeyMetadata];
-          }
-          [entry setValue:correlation.UUID.UUIDString forKey:HKPluginKeyUUID];
-          NSMutableArray* samples = [NSMutableArray array];
-          for (HKQuantitySample* sample in correlation.objects) {
-            // if an incompatible unit was passed, the sample is not included
-            if ([sample.quantity isCompatibleWithUnit:unit]) {
-              [samples addObject: @{HKPluginKeyStartDate:[df stringFromDate:sample.startDate],
-                                    HKPluginKeyEndDate:[df stringFromDate:sample.endDate],
-                                    HKPluginKeySampleType:sample.sampleType.identifier,
-                                    HKPluginKeyValue:[NSNumber numberWithDouble:[sample.quantity doubleValueForUnit:unit]], //
-                                    HKPluginKeyUnit:unit.unitString,
-                                    HKPluginKeyMetadata:sample.metadata != nil ? sample.metadata : @{},
-                                    HKPluginKeyUUID:sample.UUID.UUIDString}];
-            }
-          }
-          [entry setValue:samples forKey:HKPluginKeyObjects];
-          // TODO
-        } else if ([sample isKindOfClass:[HKQuantitySample class]]) {
-          HKQuantitySample *qsample = (HKQuantitySample *)sample;
-          // TODO compare with unit
-          [entry setValue:[NSNumber numberWithDouble:[qsample.quantity doubleValueForUnit:unit]] forKey:@"quantity"];
-          
-        } else if ([sample isKindOfClass:[HKCorrelationType class]]) {
-          // TODO
-        } else if ([sample isKindOfClass:[HKWorkout class]]) {
-          HKWorkout *wsample = (HKWorkout*)sample;
-          [entry setValue:[NSNumber numberWithDouble:wsample.duration] forKey:@"duration"];
-        }
-        
-        [finalResults addObject:entry];
-      }
-      
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:finalResults];
-        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-      });
+        return;
     }
-  }];
-  [self.healthStore executeQuery:query];
+    
+    
+    HKStatisticsCollectionQuery *query = [[HKStatisticsCollectionQuery alloc] initWithQuantityType:quantityType
+                                                                           quantitySamplePredicate:nil
+                                                                                           options:HKStatisticsOptionCumulativeSum
+                                                                                        anchorDate:anchorDate
+                                                                                intervalComponents:interval];
+    
+    // Set the results handler
+    query.initialResultsHandler = ^(HKStatisticsCollectionQuery *query, HKStatisticsCollection *results, NSError *error) {
+        if (error) {
+            // Perform proper error handling here
+            NSLog(@"*** An error occurred while calculating the statistics: %@ ***",error.localizedDescription);
+        } else
+        {
+            NSDateFormatter *df = [[NSDateFormatter alloc] init];
+            [df setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+            
+            // Get the daily steps over the past n days
+            HKUnit *unit = unitString!=nil ? [HKUnit unitFromString:unitString] : [HKUnit countUnit];
+            NSMutableArray *finalResults = [[NSMutableArray alloc] initWithCapacity:[[results statistics ] count]];
+            
+            [results
+             enumerateStatisticsFromDate:startDate
+             toDate:endDate
+             withBlock:^(HKStatistics *result, BOOL *stop) {
+                 
+                 NSDate *valueStartDate = result.startDate;
+                 NSDate *valueEndDate = result.endDate;
+                 
+                 NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                               [df stringFromDate:valueStartDate], HKPluginKeyStartDate,
+                                               [df stringFromDate:valueEndDate], HKPluginKeyEndDate,
+                                               nil];
+                 HKQuantity *quantity = result.sumQuantity;
+                 double value = [quantity doubleValueForUnit:unit];
+                 [entry setValue:[NSNumber numberWithDouble:value] forKey:@"quantity"];
+                 [finalResults addObject:entry];
+             }];
+          
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:finalResults];
+                [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+            });
+        }
+    };
+    
+    //END - Vito
+    [self.healthStore executeQuery:query];
 }
 
 - (void) saveQuantitySample:(CDVInvokedUrlCommand*)command {

--- a/www/HealthKit.js
+++ b/www/HealthKit.js
@@ -108,6 +108,8 @@ define('saveWorkout', {required: 'startDate'}, function(options) {
 define('monitorSampleType', {required: 'sampleType'});
 define('querySampleType', {required: 'sampleType'}, hasValidDates);
 
+define('queryDailySampleTypeStats', {required: 'sampleType'}, hasValidDates);
+
 define('queryCorrelationType', {required: 'correlationType'}, hasValidDates);
 define('saveQuantitySample', {required: 'sampleType'}, hasValidDates);
 


### PR DESCRIPTION
Hi,

**Date Format**

I did some changes into the code in order to get the dates formatted in ISO 8601 (see #60 ).  
We could probably move the formatter to a separate method, e.g. 
```objc
(NSDate*) formatDateToISO8601:(NSDate*)date
```

**Statistics data**

I was initially working also on solving #33 because I need to get daily steps count, heart rate average, calories and so on. Therefore I added the queryDailySampleTypeStats, which leverages  [HKStatisticsCollectionQuery](https://developer.apple.com/library/ios/documentation/HealthKit/Reference/HKStatisticsCollectionQuery_Class/) to get aggregate information from HealthKit. This method currently accepts the same argument of querySampleType, but works only with HKQuantity types.

I tested it only with steps count and heart rate average so far, so I may need to work more on it in order to get it working. And it is surely improvable, but I think it is a small step beyond.

Cheers,

Vito 