### PR TITLE
Improved error feedback on readHeight and readWeight

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -438,7 +438,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
           });
         } else {
           dispatch_async(dispatch_get_main_queue(), ^{
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorInner.localizedDescription];
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no data"];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
           });
         }
@@ -534,7 +534,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
           });
         } else {
           dispatch_async(dispatch_get_main_queue(), ^{
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorInner.localizedDescription];
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no data"];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
           });
         }

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -438,7 +438,8 @@ static NSString *const HKPluginKeyUUID = @"UUID";
           });
         } else {
           dispatch_async(dispatch_get_main_queue(), ^{
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no data"];
+            NSString * errorDescritption = errorInner.localizedDescription == nil ? @"no data" : errorInner.localizedDescription;
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorDescritption];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
           });
         }
@@ -534,7 +535,8 @@ static NSString *const HKPluginKeyUUID = @"UUID";
           });
         } else {
           dispatch_async(dispatch_get_main_queue(), ^{
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no data"];
+            NSString * errorDescritption = errorInner.localizedDescription == nil ? @"no data" : errorInner.localizedDescription;
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorDescritption];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
           });
         }


### PR DESCRIPTION
When calling readHeight and readWeight, the error handler is called with argument null even if the user has no data (e.g. brand new phone, never use Health app etc.).

This makes difficult to distinguish wether he/she gave read access to height and weight, or not.

**change:**
Now the error callback returns "no data" if no other error is found and mostRecentQuantity is null, so the consumer app can eventually distinguish between the different error cases.