### PR TITLE
dynamically add healthkit entitlements

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
 
   <engines>
     <engine name="cordova" version=">=3.0.0"/>
+    <engine name="cordova-ios" version=">=4.3.0" />
   </engines>
 
   <js-module src="www/HealthKit.js" name="HealthKit">

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,11 +52,11 @@
       <string/>
     </config-file>
 
-    <config-file target="Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
+     <config-file target="*-Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
       <true/>
     </config-file>
 
-    <config-file target="Entitlements-Release.plist" parent="com.apple.developer.healthkit">
+    <config-file target="*-Entitlements-Release.plist" parent="com.apple.developer.healthkit">
       <true/>
     </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,11 +52,11 @@
       <string/>
     </config-file>
 
-     <config-file target="*-Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
+    <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
       <true/>
     </config-file>
 
-    <config-file target="*-Entitlements-Release.plist" parent="com.apple.developer.healthkit">
+    <config-file target="*/Entitlements-Release.plist" parent="com.apple.developer.healthkit">
       <true/>
     </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,6 @@
 
   <engines>
     <engine name="cordova" version=">=3.0.0"/>
-    <engine name="cordova-ios" version=">=4.3.0" />
   </engines>
 
   <js-module src="www/HealthKit.js" name="HealthKit">

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,6 +51,14 @@
       <string/>
     </config-file>
 
+    <config-file target="Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
+      <true/>
+    </config-file>
+
+    <config-file target="Entitlements-Release.plist" parent="com.apple.developer.healthkit">
+      <true/>
+    </config-file>
+
     <header-file src="src/ios/WorkoutActivityConversion.h"/>
     <source-file src="src/ios/WorkoutActivityConversion.m"/>
     <header-file src="src/ios/HKHealthStore+AAPLExtensions.h"/>


### PR DESCRIPTION
As of cordova-ios@4.3.0 you can make direct use of a debug and release entitlement plist to dynamically add entitlements. No need for hooks. This plugin can directly add the entitlements it needs. https://github.com/Telerik-Verified-Plugins/HealthKit/issues/79