### PR TITLE
Check for valid metadata on quantitySample to avoid crash from bad metadata from Withings blood pressure sample

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -1580,7 +1580,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
                                     HKPluginKeySampleType: quantitySample.sampleType.identifier,
                                     HKPluginKeyValue: @([quantitySample.quantity doubleValueForUnit:unit]),
                                     HKPluginKeyUnit: unit.unitString,
-                                    HKPluginKeyMetadata: ((quantitySample.metadata != nil) ? quantitySample.metadata : @{}),
+                                    HKPluginKeyMetadata: (quantitySample.metadata == nil || ![NSJSONSerialization isValidJSONObject:quantitySample.metadata]) ? @{} : quantitySample.metadata,
                                     HKPluginKeyUUID: quantitySample.UUID.UUIDString
                             }
                             ];


### PR DESCRIPTION
This addresses the crash described in https://github.com/Telerik-Verified-Plugins/HealthKit/issues/87

## Smoke Test
1. Install "Health Mate" from Withings
2. Login and add a blood pressure measurement (measurement can be added manually or from Withings blood pressure cuff)
3. Sync the measurement from Health Mate to the Apple Health app (HealthKit)
4. Query for blood pressure from an app using the https://github.com/Telerik-Verified-Plugins/HealthKit