### PR TITLE
Added paramaters to populate the info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,21 @@
 Using the Cordova CLI?
 
 ```
-cordova plugin add com.telerik.plugins.healthkit
+cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access'
 ```
+`HEALTH_READ_PERMISSION` and `HEALTH_WRITE_PERMISSION` are shown when your app asks for access to data in HealthKit.
 
 Using PhoneGap Build?
 
 ```xml
 <plugin name="com.telerik.plugins.healthkit" source="npm" />
+
+<!-- Read access -->
+<config-file platform="ios" parent="NSHealthShareUsageDescription">
+  <string>App needs read access</string>
+</config-file>
+<!-- Write access -->
+<config-file platform="ios" parent="NSHealthUpdateUsageDescription">
+  <string>App needs write access</string>
+</config-file>
 ```

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,11 +44,13 @@
     </config-file-->
 
     <!-- Usage description of Health, mandatory since iOS 10 -->
+    <preference name="HEALTH_READ_PERMISSION" default=" " />
+    <preference name="HEALTH_WRITE_PERMISSION" default=" " />
     <config-file target="*-Info.plist" parent="NSHealthShareUsageDescription">
-      <string/>
+      <string>$HEALTH_READ_PERMISSION</string>
     </config-file>
     <config-file target="*-Info.plist" parent="NSHealthUpdateUsageDescription">
-      <string/>
+      <string>$HEALTH_WRITE_PERMISSION</string>
     </config-file>
 
     <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit">


### PR DESCRIPTION
`NSHealthShareUsageDescription` and `NSHealthUpdateUsageDescription` in the info.plist cannot be empty strings; any build that has those parameters set to empty strings will get rejected when trying to upload to the App Store.

Whenever I rebuild my app with `cordova build ios`, I'm required to manually edit the info.plist before uploading a build. With my proposed changes, users will be able to permanently specify values for those parameters when they install the plugin so there's no need to ever manually edit the info.plist.