### PR TITLE
Update: PhoneGap Build new builder - cli-7/8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSI
 ```
 `HEALTH_READ_PERMISSION` and `HEALTH_WRITE_PERMISSION` are shown when your app asks for access to data in HealthKit.
 
-Using PhoneGap Build?
+#### Using PhoneGap Build?
 
 ```xml
 <plugin name="com.telerik.plugins.healthkit" source="npm" />
@@ -67,3 +67,16 @@ Using PhoneGap Build?
   <string>App needs write access</string>
 </config-file>
 ```
+#### Using PhoneGap Build - cli-7 or superior?
+
+PhoneGap Build has [recently migrated](https://blog.phonegap.com/phonegap-7-0-1-now-on-build-and-it-includes-some-important-changes-89087fe465f5) from the custom build process to the standard Cordova build process. If you are already running on the new builder, it is no longer necessary to add the variables differently, and the variables must be defined as in the Cordova case.
+
+```xml
+<platform name="ios">
+    <plugin name="com.telerik.plugins.healthkit" spec="^0.5.5" >
+        <variable name="HEALTH_READ_PERMISSION" value="App needs read access" />
+        <variable name="HEALTH_WRITE_PERMISSION" value="App needs write access" />
+    </plugin>        
+</platform>
+```
+


### PR DESCRIPTION
This is a simple change to the README to document that PGB's new builder requires the same XML configuration.